### PR TITLE
Added option to ignore invalid SSH certs

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -5,3 +5,6 @@ root_dir = "<Root Directory full path>"
 username = "<LDAP Username>"
 password = "<LDAP Password>"
 url = "http://moodle.iitb.ac.in/login/index.php"
+
+[options]
+insecure_ssl = "enabled"

--- a/moodle.py
+++ b/moodle.py
@@ -17,10 +17,18 @@ root_directory = conf.get("dirs", "root_dir")
 username = conf.get("auth", "username")
 password = conf.get("auth", "password")
 authentication_url = conf.get("auth", "url")
+insecure_ssl = conf.has_option("options", "insecure_ssl") and conf.get("options", "insecure_ssl") or "disabled";
+
+ctx = ssl.create_default_context()
+# Ignore incorrect SSL certificates
+if insecure_ssl == "enabled":
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    print "Insecure SSL mode enabled: we will not check the certificates"
 
 # Store the cookies and create an opener that will hold them
 cj = cookielib.CookieJar()
-opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
+opener = urllib2.build_opener(urllib2.HTTPSHandler(context=ctx), urllib2.HTTPCookieProcessor(cj))
 
 # Add our headers
 opener.addheaders = [('User-agent', 'Moodle-Crawler')]
@@ -80,7 +88,7 @@ for course in courses:
         # Checking only resources... Ignoring forum and folders, etc
         if "resource" in href:
             cj1 = cookielib.CookieJar()
-            opener1 = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj1))
+            opener1 = urllib2.build_opener(urllib2.HTTPSHandler(context=ctx),urllib2.HTTPCookieProcessor(cj1))
 
             # Add our headers
             opener1.addheaders = [('User-agent', 'Moodle-Crawler')]


### PR DESCRIPTION
This PR will add a new option "insecure_ssl":
- insecure_ssl = disabled (default): you cannot connect to Moodle HTTPS sites with an invalid SSL cert
- insecure_ssl = enabled: it will ignore invalid SSL certs