### PR TITLE
Add a template for config.ini to avoid publishing private credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Avoid publishing private credentials
+config.ini

--- a/config.ini
+++ b/config.ini
@@ -1,7 +1,0 @@
-[dirs]
-root_dir = "<Root Directory full path>"
-
-[auth]
-username = "<LDAP Username>"
-password = "<LDAP Password>"
-url = "http://moodle.iitb.ac.in/login/index.php"


### PR DESCRIPTION
To avoid publishing private credentials, I've moved `config.ini` file to a `config.ini.dist` template, and added a .gitignore to ignore original `config.yml`.